### PR TITLE
Bump ssl version

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+ - Add "tlsv1_1" and "tlsv1_2" support, and use "tlsv1" in unit tests.
 
 1.012 2014-11-14T20:19:52Z UTC
  - Reduce memory usage and speedup writing large strings by avoiding substr

--- a/lib/POE/Component/SSLify.pm
+++ b/lib/POE/Component/SSLify.pm
@@ -283,6 +283,8 @@ L<http://www.openssl.org/docs/ssl/SSL_CTX_new.html> for more info.
 	* sslv2
 	* sslv3
 	* tlsv1
+	* tlsv1_1
+	* tlsv1_2
 	* sslv23
 	* default ( sslv23 )
 
@@ -339,21 +341,27 @@ sub SSLify_Options {
 	return 1;
 }
 
+
+my %ssl_versions = (
+	sslv2 => \&Net::SSLeay::CTX_v2_new,
+	sslv3 => \&Net::SSLeay::CTX_v3_new,
+	tlsv1 => \&Net::SSLeay::CTX_tlsv1_new,
+	tlsv1_1 => \&Net::SSLeay::CTX_tlsv1_1_new,
+	tlsv1_2 => \&Net::SSLeay::CTX_tlsv1_2_new,
+
+	# The below are equivalent
+	sslv23 => \&Net::SSLeay::CTX_v23_new,
+	default => \&Net::SSLeay::CTX_new,
+);
+
+
 sub _createSSLcontext {
 	my( $key, $cert, $version, $options ) = @_;
 
 	my $context;
 	if ( defined $version and ! ref $version ) {
-		if ( $version eq 'sslv2' ) {
-			$context = Net::SSLeay::CTX_v2_new();
-		} elsif ( $version eq 'sslv3' ) {
-			$context = Net::SSLeay::CTX_v3_new();
-		} elsif ( $version eq 'tlsv1' ) {
-			$context = Net::SSLeay::CTX_tlsv1_new();
-		} elsif ( $version eq 'sslv23' ) {
-			$context = Net::SSLeay::CTX_v23_new();
-		} elsif ( $version eq 'default' ) {
-			$context = Net::SSLeay::CTX_new();
+		if ($ssl_versions{$version}) {
+			$context = $ssl_versions{$version}->();
 		} else {
 			die "unknown SSL version: $version";
 		}

--- a/t/renegotiate_client.t
+++ b/t/renegotiate_client.t
@@ -41,8 +41,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -104,7 +104,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/renegotiate_client_pings.t
+++ b/t/renegotiate_client_pings.t
@@ -43,8 +43,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -107,7 +107,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/renegotiate_server.t
+++ b/t/renegotiate_server.t
@@ -41,8 +41,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -104,7 +104,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/simple.t
+++ b/t/simple.t
@@ -38,8 +38,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -98,7 +98,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/simple_large.t
+++ b/t/simple_large.t
@@ -40,8 +40,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -100,7 +100,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/simple_parallel.t
+++ b/t/simple_parallel.t
@@ -38,8 +38,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -98,7 +98,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/simple_parallel_large.t
+++ b/t/simple_parallel_large.t
@@ -40,8 +40,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -98,7 +98,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/simple_parallel_superbig.t
+++ b/t/simple_parallel_superbig.t
@@ -49,8 +49,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -107,7 +107,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/simple_superbig.t
+++ b/t/simple_superbig.t
@@ -48,8 +48,8 @@ POE::Component::Server::TCP->new
 	},
 	ClientPreConnect	=> sub
 	{
-		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+		eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+		eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 		ok(!$@, "SERVER: SSLify_Options $@");
 
 		my $socket = eval { Server_SSLify($_[ARG0]) };
@@ -110,7 +110,7 @@ POE::Component::Client::TCP->new
 	},
 	PreConnect	=> sub
 	{
-		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+		my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 		ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 		my $socket = eval { Client_SSLify($_[ARG0], undef, undef, $ctx) };
 		ok(!$@, "CLIENT: Client_SSLify $@");

--- a/t/upgrade.t
+++ b/t/upgrade.t
@@ -45,8 +45,8 @@ POE::Component::Server::TCP->new
 			$heap->{client}->flush; # make sure we sent the pong
 
 			# sslify it in-situ!
-			eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'sslv3') };
-			eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'sslv3') } if ($@);
+			eval { SSLify_Options('mylib/example.key', 'mylib/example.crt', 'tlsv1') };
+			eval { SSLify_Options('../mylib/example.key', '../mylib/example.crt', 'tlsv1') } if ($@);
 			ok(!$@, "SERVER: SSLify_Options $@");
 			my $socket = eval { Server_SSLify($heap->{client}->get_output_handle) };
 			ok(!$@, "SERVER: Server_SSLify $@");
@@ -115,7 +115,7 @@ POE::Component::Client::TCP->new
 			ok(1, "CLIENT: recv: $line");
 
 			# sslify it in-situ!
-			my $ctx = eval { SSLify_ContextCreate(undef, undef, 'sslv3') };
+			my $ctx = eval { SSLify_ContextCreate(undef, undef, 'tlsv1') };
 			ok(!$@, "CLIENT: SSLify_ContextCreate $@");
 			my $socket = eval { Client_SSLify($heap->{server}->get_output_handle, undef, undef, $ctx) };
 			ok(!$@, "CLIENT: Client_SSLify $@");


### PR DESCRIPTION
Hello! I'm not well versed in SSL, but this is essentially the unit test fix from https://rt.cpan.org/Public/Bug/Display.html?id=104493 . And I added support for newer SSL versions. I tested "tlsv1", "tlsv1_1", and "tlsv1_2" against openssl 1.0.2g, and everything seems OK.